### PR TITLE
Include redis

### DIFF
--- a/stubs/docker-compose.stub
+++ b/stubs/docker-compose.stub
@@ -34,7 +34,21 @@ services:
             - sail
         volumes:
             - /var/run/docker.sock:/tmp/docker.sock:ro
+    redis:
+        image: 'redis:alpine'
+        ports:
+            - '${FORWARD_REDIS_PORT:-6379}:6379'
+        volumes:
+            - 'sail-redis:/data'
+        networks:
+            - sail
+        healthcheck:
+            test: ["CMD", "redis-cli", "ping"]
+            retries: 3
+            timeout: 5s
 networks:
     sail:
         driver: bridge
 {{volumes}}
+    sail-redis:
+        driver: local


### PR DESCRIPTION
Include the official redis container, as most of our Laravel apps use it for sessions/caching and some of them use it for queue functionality.

**This will need testing on Apple silicone**
